### PR TITLE
Render aligned damagers and healers tables in loot embed

### DIFF
--- a/config/bossThumbnails.js
+++ b/config/bossThumbnails.js
@@ -72,7 +72,7 @@ module.exports = {
   "Валитрия Сноходица": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-valithria-dreamwalker.png",
   "Синдрагоса": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-sindragosa.png",
   "Король-лич": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-the-lich-king.png",
-  "Леди Джайна Праудмур": "https://wow.zamimg.com/modelviewer/wrath/webthumbs/npc/147/30867.webp",
+  "Леди Джайна Праудмур": "https://wow.zamimg.com/modelviewer/wrath/webthumbs/npc/147/30867.png",
 
   // Рубиновое святилище
   "Халион": "https://wow.zamimg.com/uploads/screenshots/small/171307-halion.jpg",
@@ -108,7 +108,7 @@ module.exports = {
   // Змеиное святилище
   "Гидросс Нестабильный": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-hydross-the-unstable.png",
   "Скрытень из глубин": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-the-lurker-below.png",
-  "Горе'лац": "https://wow.zamimg.com/modelviewer/wrath/webthumbs/npc/184/5560.webp",
+  "Горе'лац": "https://wow.zamimg.com/modelviewer/wrath/webthumbs/npc/184/5560.png",
   "Леотерас Слепец": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-leotheras-the-blind.png",
   "Повелитель глубин Каратресс": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-fathom-lord-karathress.png",
   "Морогрим Волноступ": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-morogrim-tidewalker.png",
@@ -128,23 +128,23 @@ module.exports = {
   "Архимонд": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-archimonde.png",
 
   // Черный храм
-  "Верховный полководец Надж'ентус": "https://sirus.su/images/encounterjournal/ui-ej-boss-high-warlord-najentus.webp",
-  "Супремус": "https://sirus.su/images/encounterjournal/ui-ej-boss-supremus.webp",
-  "Тень Акамы": "https://sirus.su/images/encounterjournal/ui-ej-boss-shade-of-akama.webp",
-  "Терон Кровожад": "https://sirus.su/images/encounterjournal/ui-ej-boss-teron-gorefiend.webp",
-  "Гуртогг Кипящая Кровь": "https://sirus.su/images/encounterjournal/ui-ej-boss-gurtogg-bloodboil.webp",
-  "Реликварий душ": "https://sirus.su/images/encounterjournal/ui-ej-boss-reliquary-of-souls.webp",
+  "Верховный полководец Надж'ентус": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-high-warlord-najentus.png",
+  "Супремус": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-supremus.png",
+  "Тень Акамы": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-shade-of-akama.png",
+  "Терон Кровожад": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-teron-gorefiend.png",
+  "Гуртогг Кипящая Кровь": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-gurtogg-bloodboil.png",
+  "Реликварий Душ": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-reliquary-of-souls.png",
 
   // Тюрьма Тол'гарода
-  "Гогонаш": "https://sirus.su/images/encounterjournal/ui-ej-boss-argaloth.webp",
-  "Поглотитель разума Ктракс": "https://sirus.su/images/encounterjournal/ui-ej-boss-herald-volazj.webp",
-  "Пожиратель магии": "https://sirus.su/images/encounterjournal/ui-ej-boss-shadhar.webp",
+  "Гогонаш": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-argaloth.png",
+  "Поглотитель разума Ктракс": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-herald-volazj.png",
+  "Пожиратель магии": "https://wow.zamimg.com/images/wow/journal/ui-ej-boss-shadhar.png",
 
   // Зорт
-  "Зорт": "https://sirus.su/images/zones/naxxramas.jpg",
+  "Зорт": "https://sirus.su/images/zones/naxxramas.webp",
 
   // Бронзовое святилище
-  "Импорус": "https://sirus.su/images/encounterjournal/ui-ej-boss-emporus.webp",
-  "Исказитель времени Элонус": "https://sirus.su/images/encounterjournal/ui-ej-boss-elonus.webp",
-  "Мурозонд": "https://sirus.su/images/images/encounterjournal/ui-ej-boss-murozond.webp"
+  "Импорус": "https://sirus.su//images/encounterjournal/ui-ej-boss-emporus.webp",
+  "Исказитель времени Элонус": "https://sirus.su//images/encounterjournal/ui-ej-boss-elonus.webp",
+  "Мурозонд": "https://sirus.su//images/encounterjournal/ui-ej-boss-murozond.webp"
 };

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -212,19 +212,9 @@ function formatPlayersTable(rows, valueLabel) {
     return "\u200b";
   }
 
-  const getVisibleLength = (text) =>
-    text.replace(/<a?:\w+:\d+>/g, "x").replace(/\*\*/g, "").length;
-
-  const placeWidth = Math.max(
-    ...rows.map((row) => getVisibleLength(String(row.place))),
-  );
-
-  const padColumn = (text, width) => {
-    const padding = Math.max(0, width - getVisibleLength(text) + 1);
-    return `${text}${INVISIBLE_SPACE.repeat(padding)}`;
-  };
   const lines = rows.map((row) => {
-    const place = padColumn(`**${row.place}**`, placeWidth);
+    const placePadding = row.place >= 10 ? 1 : 2;
+    const place = `**${row.place}**${INVISIBLE_SPACE.repeat(placePadding)}`;
     return `${place}${row.name} \`${row.value}\``;
   });
 

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -216,19 +216,37 @@ function formatPlayersTable(rows, valueLabel) {
     return `${text}${INVISIBLE_SPACE.repeat(padding)}`;
   };
 
-  const lines = [
-    `${padColumn(header.place, placeWidth)}${padColumn(
-      header.name,
-      nameWidth,
-    )}${header.value}`,
-    ...rows.map((row) => {
-      const place = padColumn(String(row.place), placeWidth);
-      const name = padColumn(row.name, nameWidth);
-      return `${place}${name}${row.value}`;
-    }),
-  ];
+  const headerLine = `${padColumn(header.place, placeWidth)}${padColumn(
+    header.name,
+    nameWidth,
+  )}${header.value}`;
 
-  return lines.join("\n");
+  const lines = [headerLine];
+  for (const row of rows) {
+    const place = padColumn(String(row.place), placeWidth);
+    const name = padColumn(row.name, nameWidth);
+    lines.push(`${place}${name}${row.value}`);
+  }
+
+  const trimmedLines = [];
+  for (const line of lines) {
+    const next = trimmedLines.length === 0 ? line : `${trimmedLines.join("\n")}\n${line}`;
+    if (next.length > 1024) {
+      if (trimmedLines.length === 0) {
+        return headerLine.slice(0, 1024);
+      }
+
+      const overflowLine = "…";
+      const overflowCandidate = `${trimmedLines.join("\n")}\n${overflowLine}`;
+      if (overflowCandidate.length <= 1024) {
+        return overflowCandidate;
+      }
+      return trimmedLines.join("\n");
+    }
+    trimmedLines.push(line);
+  }
+
+  return trimmedLines.join("\n");
 }
 
 /**

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -141,12 +141,7 @@ function addDpsSection(embed, rows, summaryDps) {
       inline: true,
     },
   );
-  embed.addFields(
-    {
-      name: "Дамагеры",
-      value: formatPlayersTable(rows, "Урон"),
-    },
-  );
+  addPlayerTableFields(embed, rows, "Дамагеры", "Урон");
   return embed;
 }
 
@@ -176,13 +171,34 @@ function addHpsSection(embed, rows, summaryHps) {
       inline: true,
     },
   );
-  embed.addFields(
-    {
-      name: "Хиллеры",
-      value: formatPlayersTable(rows, "Лечение"),
-    },
-  );
+  addPlayerTableFields(embed, rows, "Хиллеры", "Лечение");
   return embed;
+}
+
+/**
+ * Adds player table fields in chunks of 10
+ * @param {import('discord.js').EmbedBuilder} embed - Embed message
+ * @param {Array<Object>} rows - Player rows
+ * @param {string} title - Field title
+ * @param {string} valueLabel - Value label
+ */
+function addPlayerTableFields(embed, rows, title, valueLabel) {
+  const chunkSize = 10;
+  if (!rows || rows.length === 0) {
+    embed.addFields({
+      name: title,
+      value: "\u200b",
+    });
+    return;
+  }
+
+  for (let index = 0; index < rows.length; index += chunkSize) {
+    const chunk = rows.slice(index, index + chunkSize);
+    embed.addFields({
+      name: index === 0 ? title : "\u200b",
+      value: formatPlayersTable(chunk, valueLabel),
+    });
+  }
 }
 
 /**
@@ -212,21 +228,7 @@ function formatPlayersTable(rows, valueLabel) {
     return `${place}${row.name} \`${row.value}\``;
   });
 
-  const trimmedLines = [];
-  for (const line of lines) {
-    const next = trimmedLines.length === 0 ? line : `${trimmedLines.join("\n")}\n${line}`;
-    if (next.length > 1024) {
-      const overflowLine = "…";
-      const overflowCandidate = `${trimmedLines.join("\n")}\n${overflowLine}`;
-      if (overflowCandidate.length <= 1024) {
-        return overflowCandidate;
-      }
-      return trimmedLines.join("\n");
-    }
-    trimmedLines.push(line);
-  }
-
-  return trimmedLines.join("\n");
+  return lines.join("\n");
 }
 
 /**

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -14,7 +14,6 @@ const { formatShortValue } = require("../../utils/formatters.js");
 const sirusApi = require("../../api/sirusApi.js");
 
 const INVISIBLE_SPACE = "\u2800";
-const PAD_SPACE = " ";
 
 /**
  * Creates a complete boss kill message with all sections
@@ -198,7 +197,7 @@ function formatPlayersTable(rows, valueLabel) {
   }
 
   const getVisibleLength = (text) =>
-    text.replace(/<a?:\w+:\d+>/g, "x").length;
+    text.replace(/<a?:\w+:\d+>/g, "x").replace(/\*\*/g, "").length;
 
   const placeWidth = Math.max(
     ...rows.map((row) => getVisibleLength(String(row.place))),
@@ -211,38 +210,27 @@ function formatPlayersTable(rows, valueLabel) {
     const padding = Math.max(0, width - getVisibleLength(text) + 1);
     return `${text}${INVISIBLE_SPACE.repeat(padding)}`;
   };
-  const padValue = (text, width) => {
-    const padding = Math.max(0, width - getVisibleLength(text));
-    return `${PAD_SPACE.repeat(padding)}${text}`;
-  };
-
-  const valueWidth = Math.max(
-    ...rows.map((row) => getVisibleLength(row.value)),
-  );
-
   const lines = rows.map((row) => {
-    const place = padColumn(String(row.place), placeWidth);
+    const place = padColumn(`**${row.place}**`, placeWidth);
     const name = padColumn(row.name, nameWidth);
-    return `${place}${name}${padValue(row.value, valueWidth)}`;
+    return `${place}${name} \`${row.value}\``;
   });
 
   const trimmedLines = [];
   for (const line of lines) {
     const next = trimmedLines.length === 0 ? line : `${trimmedLines.join("\n")}\n${line}`;
-    const nextWithFence = `\`\`\`\n${next}\n\`\`\``;
-    if (nextWithFence.length > 1024) {
+    if (next.length > 1024) {
       const overflowLine = "…";
       const overflowCandidate = `${trimmedLines.join("\n")}\n${overflowLine}`;
-      const overflowWithFence = `\`\`\`\n${overflowCandidate}\n\`\`\``;
-      if (overflowWithFence.length <= 1024) {
-        return overflowWithFence;
+      if (overflowCandidate.length <= 1024) {
+        return overflowCandidate;
       }
-      return `\`\`\`\n${trimmedLines.join("\n")}\n\`\`\``;
+      return trimmedLines.join("\n");
     }
     trimmedLines.push(line);
   }
 
-  return `\`\`\`\n${trimmedLines.join("\n")}\n\`\`\``;
+  return trimmedLines.join("\n");
 }
 
 /**

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -94,7 +94,7 @@ function createBossKillEmbed({
       iconURL: guildIcon,
       url: sirusApi.getGuildUrl(realmId, bossKillInfo.guild.id),
     },
-    title: `Убийство босса ${bossKillInfo.boss_name}`,
+    title: `${bossKillInfo.map_name} — ${bossKillInfo.boss_name}`,
     url: sirusApi.getPveProgressUrl(realmId, recordId),
   }).addFields(
     {
@@ -126,18 +126,18 @@ function addDpsSection(embed, rows, summaryDps) {
   addEmptyField(embed);
   embed.addFields(
     {
-      name: "\u200b",
-      value: "\u200b",
-      inline: true,
-    },
-    {
-      name: "\u200b",
-      value: "\u200b",
-      inline: true,
-    },
-    {
       name: "Общий DPS",
-      value: formatShortValue(summaryDps),
+      value: "```ansi\n" + `[2;31m${formatShortValue(summaryDps)}[0m\n` + "```",
+      inline: true,
+    },
+    {
+      name: "\u200b",
+      value: "\u200b",
+      inline: true,
+    },
+    {
+      name: "\u200b",
+      value: "\u200b",
       inline: true,
     },
   );
@@ -156,18 +156,18 @@ function addHpsSection(embed, rows, summaryHps) {
   addEmptyField(embed);
   embed.addFields(
     {
-      name: "\u200b",
-      value: "\u200b",
-      inline: true,
-    },
-    {
-      name: "\u200b",
-      value: "\u200b",
-      inline: true,
-    },
-    {
       name: "Общий HPS",
-      value: formatShortValue(summaryHps),
+      value: "```ansi\n" + `[2;36m${formatShortValue(summaryHps)}[0m` + "```",
+      inline: true,
+    },
+    {
+      name: "\u200b",
+      value: "\u200b",
+      inline: true,
+    },
+    {
+      name: "\u200b",
+      value: "\u200b",
       inline: true,
     },
   );
@@ -196,7 +196,7 @@ function addPlayerTableFields(embed, rows, title, valueLabel) {
     const chunk = rows.slice(index, index + chunkSize);
     embed.addFields({
       name: index === 0 ? title : "\u200b",
-      value: formatPlayersTable(chunk, valueLabel),
+      value: formatPlayersTable(chunk),
     });
   }
 }
@@ -204,10 +204,9 @@ function addPlayerTableFields(embed, rows, title, valueLabel) {
 /**
  * Builds aligned table for player rows
  * @param {Array<Object>} rows - Player rows
- * @param {string} valueLabel - Value column label
  * @returns {string}
  */
-function formatPlayersTable(rows, valueLabel) {
+function formatPlayersTable(rows) {
   if (!rows || rows.length === 0) {
     return "\u200b";
   }

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -202,9 +202,6 @@ function formatPlayersTable(rows, valueLabel) {
   const placeWidth = Math.max(
     ...rows.map((row) => getVisibleLength(String(row.place))),
   );
-  const nameWidth = Math.max(
-    ...rows.map((row) => getVisibleLength(row.name)),
-  );
 
   const padColumn = (text, width) => {
     const padding = Math.max(0, width - getVisibleLength(text) + 1);
@@ -212,8 +209,7 @@ function formatPlayersTable(rows, valueLabel) {
   };
   const lines = rows.map((row) => {
     const place = padColumn(`**${row.place}**`, placeWidth);
-    const name = padColumn(row.name, nameWidth);
-    return `${place}${name} \`${row.value}\``;
+    return `${place}${row.name} \`${row.value}\``;
   });
 
   const trimmedLines = [];

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -196,15 +196,18 @@ function formatPlayersTable(rows, valueLabel) {
     return "\u200b";
   }
 
+  const getVisibleLength = (text) =>
+    text.replace(/<a?:\w+:\d+>/g, "x").length;
+
   const placeWidth = Math.max(
-    ...rows.map((row) => String(row.place).length),
+    ...rows.map((row) => getVisibleLength(String(row.place))),
   );
   const nameWidth = Math.max(
-    ...rows.map((row) => row.name.length),
+    ...rows.map((row) => getVisibleLength(row.name)),
   );
 
   const padColumn = (text, width) => {
-    const padding = Math.max(0, width - text.length + 1);
+    const padding = Math.max(0, width - getVisibleLength(text) + 1);
     return `${text}${INVISIBLE_SPACE.repeat(padding)}`;
   };
 

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -14,7 +14,7 @@ const { formatShortValue } = require("../../utils/formatters.js");
 const sirusApi = require("../../api/sirusApi.js");
 
 const INVISIBLE_SPACE = "\u2800";
-const FIGURE_SPACE = "\u2007";
+const PAD_SPACE = ` ${INVISIBLE_SPACE}`;
 
 /**
  * Creates a complete boss kill message with all sections
@@ -213,7 +213,7 @@ function formatPlayersTable(rows, valueLabel) {
   };
   const padValue = (text, width) => {
     const padding = Math.max(0, width - getVisibleLength(text));
-    return `${FIGURE_SPACE.repeat(padding)}${text}`;
+    return `${PAD_SPACE.repeat(padding)}${text}`;
   };
 
   const valueWidth = Math.max(

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -141,7 +141,7 @@ function addDpsSection(embed, rows, summaryDps) {
       inline: true,
     },
   );
-  addPlayerTableFields(embed, rows, "Дамагеры", "Урон");
+  addPlayerTableFields(embed, rows, "Дамагеры");
   return embed;
 }
 
@@ -171,7 +171,7 @@ function addHpsSection(embed, rows, summaryHps) {
       inline: true,
     },
   );
-  addPlayerTableFields(embed, rows, "Хиллеры", "Лечение");
+  addPlayerTableFields(embed, rows, "Хиллеры");
   return embed;
 }
 
@@ -180,9 +180,8 @@ function addHpsSection(embed, rows, summaryHps) {
  * @param {import('discord.js').EmbedBuilder} embed - Embed message
  * @param {Array<Object>} rows - Player rows
  * @param {string} title - Field title
- * @param {string} valueLabel - Value label
  */
-function addPlayerTableFields(embed, rows, title, valueLabel) {
+function addPlayerTableFields(embed, rows, title) {
   const chunkSize = 10;
   if (!rows || rows.length === 0) {
     embed.addFields({
@@ -214,7 +213,7 @@ function formatPlayersTable(rows) {
   const lines = rows.map((row) => {
     const placePadding = row.place >= 10 ? 1 : 2;
     const place = `**${row.place}**${INVISIBLE_SPACE.repeat(placePadding)}`;
-    return `${place}${row.name} \`${row.value}\``;
+    return `${place}${row.name} \`${row.value}\` \`(${row.percent}%)\``;
   });
 
   return lines.join("\n");

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -14,6 +14,7 @@ const { formatShortValue } = require("../../utils/formatters.js");
 const sirusApi = require("../../api/sirusApi.js");
 
 const INVISIBLE_SPACE = "\u2800";
+const FIGURE_SPACE = "\u2007";
 
 /**
  * Creates a complete boss kill message with all sections
@@ -210,11 +211,19 @@ function formatPlayersTable(rows, valueLabel) {
     const padding = Math.max(0, width - getVisibleLength(text) + 1);
     return `${text}${INVISIBLE_SPACE.repeat(padding)}`;
   };
+  const padValue = (text, width) => {
+    const padding = Math.max(0, width - getVisibleLength(text));
+    return `${FIGURE_SPACE.repeat(padding)}${text}`;
+  };
+
+  const valueWidth = Math.max(
+    ...rows.map((row) => getVisibleLength(row.value)),
+  );
 
   const lines = rows.map((row) => {
     const place = padColumn(String(row.place), placeWidth);
     const name = padColumn(row.name, nameWidth);
-    return `${place}${name}${row.value}`;
+    return `${place}${name}${padValue(row.value, valueWidth)}`;
   });
 
   const trimmedLines = [];

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -196,46 +196,28 @@ function formatPlayersTable(rows, valueLabel) {
     return "\u200b";
   }
 
-  const header = {
-    place: "Место",
-    name: "Имя",
-    value: valueLabel,
-  };
-
   const placeWidth = Math.max(
-    header.place.length,
     ...rows.map((row) => String(row.place).length),
   );
   const nameWidth = Math.max(
-    header.name.length,
     ...rows.map((row) => row.name.length),
   );
 
   const padColumn = (text, width) => {
-    const padding = Math.max(0, width - text.length + 2);
+    const padding = Math.max(0, width - text.length + 1);
     return `${text}${INVISIBLE_SPACE.repeat(padding)}`;
   };
 
-  const headerLine = `${padColumn(header.place, placeWidth)}${padColumn(
-    header.name,
-    nameWidth,
-  )}${header.value}`;
-
-  const lines = [headerLine];
-  for (const row of rows) {
+  const lines = rows.map((row) => {
     const place = padColumn(String(row.place), placeWidth);
     const name = padColumn(row.name, nameWidth);
-    lines.push(`${place}${name}${row.value}`);
-  }
+    return `${place}${name}${row.value}`;
+  });
 
   const trimmedLines = [];
   for (const line of lines) {
     const next = trimmedLines.length === 0 ? line : `${trimmedLines.join("\n")}\n${line}`;
     if (next.length > 1024) {
-      if (trimmedLines.length === 0) {
-        return headerLine.slice(0, 1024);
-      }
-
       const overflowLine = "…";
       const overflowCandidate = `${trimmedLines.join("\n")}\n${overflowLine}`;
       if (overflowCandidate.length <= 1024) {

--- a/discord/builders/lootEmbedBuilder.js
+++ b/discord/builders/lootEmbedBuilder.js
@@ -14,7 +14,7 @@ const { formatShortValue } = require("../../utils/formatters.js");
 const sirusApi = require("../../api/sirusApi.js");
 
 const INVISIBLE_SPACE = "\u2800";
-const PAD_SPACE = ` ${INVISIBLE_SPACE}`;
+const PAD_SPACE = " ";
 
 /**
  * Creates a complete boss kill message with all sections
@@ -229,18 +229,20 @@ function formatPlayersTable(rows, valueLabel) {
   const trimmedLines = [];
   for (const line of lines) {
     const next = trimmedLines.length === 0 ? line : `${trimmedLines.join("\n")}\n${line}`;
-    if (next.length > 1024) {
+    const nextWithFence = `\`\`\`\n${next}\n\`\`\``;
+    if (nextWithFence.length > 1024) {
       const overflowLine = "…";
       const overflowCandidate = `${trimmedLines.join("\n")}\n${overflowLine}`;
-      if (overflowCandidate.length <= 1024) {
-        return overflowCandidate;
+      const overflowWithFence = `\`\`\`\n${overflowCandidate}\n\`\`\``;
+      if (overflowWithFence.length <= 1024) {
+        return overflowWithFence;
       }
-      return trimmedLines.join("\n");
+      return `\`\`\`\n${trimmedLines.join("\n")}\n\`\`\``;
     }
     trimmedLines.push(line);
   }
 
-  return trimmedLines.join("\n");
+  return `\`\`\`\n${trimmedLines.join("\n")}\n\`\`\``;
 }
 
 /**

--- a/utils/playerParsers.js
+++ b/utils/playerParsers.js
@@ -47,6 +47,7 @@ function parseDpsPlayers(data, client) {
         place: i++,
         name: (emoji ? `${emoji} ` : "") + player.name,
         value: formatShortValue(dps_int),
+        intValue: dps_int,
       });
       summary_dps += dps_int;
     } else {
@@ -54,12 +55,18 @@ function parseDpsPlayers(data, client) {
         place: i++,
         name: (emoji ? `${emoji} ` : "") + player.name,
         value: "0k",
+        intValue: 0,
       });
     }
   }
 
   if (rows.length === 0) {
     return [[], 0];
+  }
+
+  for (let i = 0; i < rows.length; i++) {
+    const percent = (rows[i].intValue / summary_dps) * 100;
+    rows[i].percent = Math.round(percent * 100) / 100;
   }
 
   return [rows, summary_dps];
@@ -92,6 +99,7 @@ function parseHealPlayers(data, client) {
         place: i++,
         name: (emoji ? `${emoji} ` : "") + player.name,
         value: formatShortValue(hpsInt),
+        intValue: hpsInt,
       });
       summary_hps += hpsInt;
     } else {
@@ -99,12 +107,18 @@ function parseHealPlayers(data, client) {
         place: i++,
         name: (emoji ? `${emoji} ` : "") + player.name,
         value: "0k",
+        intValue: 0,
       });
     }
   }
 
   if (rows.length === 0) {
     return [[], 0];
+  }
+
+  for (let i = 0; i < rows.length; i++) {
+    const percent = (rows[i].intValue / summary_hps) * 100;
+    rows[i].percent = Math.round(percent * 100) / 100;
   }
 
   return [rows, summary_hps];

--- a/utils/playerParsers.js
+++ b/utils/playerParsers.js
@@ -24,15 +24,13 @@ function getPlayerEmoji(player, client) {
  * Parses DPS player data
  * @param {Array} data - Array of player data
  * @param {Object} client - Discord client
- * @returns {Array} [places, players, dps, summary_dps]
+ * @returns {Array} [rows, summary_dps]
  */
 function parseDpsPlayers(data, client) {
   data.sort((a, b) => b.dps - a.dps);
 
   let i = 1;
-  let places = "";
-  let players = "";
-  let dps = "";
+  const rows = [];
   let summary_dps = 0;
 
   for (const player of data) {
@@ -43,38 +41,41 @@ function parseDpsPlayers(data, client) {
 
     const emoji = getPlayerEmoji(player, client);
 
-    places += `**${i++}**\n`;
-    players += (emoji ? `${emoji}` : "") + `${player.name}\n`;
-
     const dps_int = parseInt(player.dps);
     if (dps_int) {
-      dps += `${formatShortValue(dps_int)}\n`;
+      rows.push({
+        place: i++,
+        name: (emoji ? `${emoji} ` : "") + player.name,
+        value: formatShortValue(dps_int),
+      });
       summary_dps += dps_int;
     } else {
-      dps += "0k\n";
+      rows.push({
+        place: i++,
+        name: (emoji ? `${emoji} ` : "") + player.name,
+        value: "0k",
+      });
     }
   }
 
-  if (places === "" || players === "" || dps === "") {
-    return ["\u200b", "\u200b", "\u200b", 0];
+  if (rows.length === 0) {
+    return [[], 0];
   }
 
-  return [places, players, dps, summary_dps];
+  return [rows, summary_dps];
 }
 
 /**
  * Parses HPS player data (healers)
  * @param {Array} data - Array of player data
  * @param {Object} client - Discord client
- * @returns {Array} [places, players, hps, summary_hps]
+ * @returns {Array} [rows, summary_hps]
  */
 function parseHealPlayers(data, client) {
   data.sort((a, b) => b.hps - a.hps);
 
   let i = 1;
-  let places = "";
-  let players = "";
-  let hps = "";
+  const rows = [];
   let summary_hps = 0;
 
   for (const player of data) {
@@ -85,23 +86,28 @@ function parseHealPlayers(data, client) {
 
     const emoji = getPlayerEmoji(player, client);
 
-    places += `**${i++}**\n`;
-    players += (emoji ? `${emoji}` : "") + `${player.name}\n`;
-
     const hpsInt = parseInt(player.hps);
     if (hpsInt) {
-      hps += `${formatShortValue(hpsInt)}\n`;
+      rows.push({
+        place: i++,
+        name: (emoji ? `${emoji} ` : "") + player.name,
+        value: formatShortValue(hpsInt),
+      });
       summary_hps += hpsInt;
     } else {
-      hps += "0k\n";
+      rows.push({
+        place: i++,
+        name: (emoji ? `${emoji} ` : "") + player.name,
+        value: "0k",
+      });
     }
   }
 
-  if (places === "" || players === "" || hps === "") {
-    return ["\u200b", "\u200b", "\u200b", 0];
+  if (rows.length === 0) {
+    return [[], 0];
   }
 
-  return [places, players, hps, summary_hps];
+  return [rows, summary_hps];
 }
 
 module.exports = {


### PR DESCRIPTION
### Motivation
- Improve the player lists in boss-loot embeds by rendering damagers and healers as aligned tables in single embed fields instead of separate multi-column strings. 
- Use an invisible space character to ensure fixed-width-like alignment within Discord embed fields.

### Description
- Changed DPS/HPS parsers in `utils/playerParsers.js` to return structured row objects (`{ place, name, value }`) and a numeric summary instead of preformatted multiline strings. 
- Updated `discord/builders/lootEmbedBuilder.js` to consume the new row format and render two single fields named `Дамагеры` and `Хиллеры` containing aligned tables. 
- Added `INVISIBLE_SPACE = "\u2800"` and the `formatPlayersTable(rows, valueLabel)` helper that computes column widths and pads columns using the invisible space to align `Место`, `Имя`, and `Урон/Лечение`. 
- Updated JSDoc comments to reflect new `dpsData`/`hpsData` shapes.

### Testing
- No automated tests were executed for this change.
- Basic smoke inspected by committing and verifying the modified files compile (no runtime tests performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982af3a2fe8832db613cd2ccfbb5d9c)