### PR TITLE
Add docker clear-cache command and expose loot tooltip cache clear (item-only key)

### DIFF
--- a/db/database.js
+++ b/db/database.js
@@ -54,6 +54,8 @@ module.exports = {
     lootTooltipCacheService.getTooltipCache.bind(lootTooltipCacheService),
   saveLootTooltipCache:
     lootTooltipCacheService.saveTooltipCache.bind(lootTooltipCacheService),
+  clearLootTooltipCache:
+    lootTooltipCacheService.clearTooltipCache.bind(lootTooltipCacheService),
 
   // Records operations
   initRecords: recordsService.initRecords.bind(recordsService),

--- a/db/models/LootTooltipCache.model.js
+++ b/db/models/LootTooltipCache.model.js
@@ -2,16 +2,11 @@ const mongoose = require("mongoose");
 
 /**
  * Loot Tooltip Cache Schema
- * Stores rendered tooltip HTML by item and realm IDs
+ * Stores rendered tooltip HTML by item ID
  */
 const lootTooltipCacheSchema = new mongoose.Schema(
   {
     item_entry: {
-      type: Number,
-      required: true,
-      index: true,
-    },
-    realm_id: {
       type: Number,
       required: true,
       index: true,
@@ -27,7 +22,7 @@ const lootTooltipCacheSchema = new mongoose.Schema(
   },
 );
 
-lootTooltipCacheSchema.index({ item_entry: 1, realm_id: 1 }, { unique: true });
+lootTooltipCacheSchema.index({ item_entry: 1 }, { unique: true });
 
 const LootTooltipCache = mongoose.model(
   "LootTooltipCache",

--- a/db/repositories/LootTooltipCacheRepository.js
+++ b/db/repositories/LootTooltipCacheRepository.js
@@ -6,13 +6,13 @@ class LootTooltipCacheRepository extends BaseRepository {
     super(LootTooltipCache);
   }
 
-  async findByItemAndRealm(itemEntry, realmId) {
-    return this.findOne({ item_entry: itemEntry, realm_id: realmId });
+  async findByItem(itemEntry) {
+    return this.findOne({ item_entry: itemEntry });
   }
 
-  async upsertTooltipCache(itemEntry, realmId, tooltipHtml) {
+  async upsertTooltipCache(itemEntry, tooltipHtml) {
     return this.model.findOneAndUpdate(
-      { item_entry: itemEntry, realm_id: realmId },
+      { item_entry: itemEntry },
       {
         $set: {
           tooltip_html: tooltipHtml,
@@ -20,6 +20,10 @@ class LootTooltipCacheRepository extends BaseRepository {
       },
       { new: true, upsert: true, setDefaultsOnInsert: true },
     );
+  }
+
+  async clearTooltipCache() {
+    return this.model.deleteMany({});
   }
 }
 

--- a/db/services/LootTooltipCacheService.js
+++ b/db/services/LootTooltipCacheService.js
@@ -2,28 +2,36 @@ const logger = require("../../logger.js");
 const { lootTooltipCacheRepository } = require("../repositories/index.js");
 
 class LootTooltipCacheService {
-  async getTooltipCache(itemEntry, realmId) {
+  async getTooltipCache(itemEntry) {
     try {
-      return await lootTooltipCacheRepository.findByItemAndRealm(itemEntry, realmId);
+      return await lootTooltipCacheRepository.findByItem(itemEntry);
     } catch (error) {
       logger.error(
-        `Error getting tooltip cache for item ${itemEntry} realm ${realmId}: ${error.message}`,
+        `Error getting tooltip cache for item ${itemEntry}: ${error.message}`,
       );
       return null;
     }
   }
 
-  async saveTooltipCache(itemEntry, realmId, tooltipHtml) {
+  async saveTooltipCache(itemEntry, tooltipHtml) {
     try {
       return await lootTooltipCacheRepository.upsertTooltipCache(
         itemEntry,
-        realmId,
         tooltipHtml,
       );
     } catch (error) {
       logger.error(
-        `Error saving tooltip cache for item ${itemEntry} realm ${realmId}: ${error.message}`,
+        `Error saving tooltip cache for item ${itemEntry}: ${error.message}`,
       );
+      return null;
+    }
+  }
+
+  async clearTooltipCache() {
+    try {
+      return await lootTooltipCacheRepository.clearTooltipCache();
+    } catch (error) {
+      logger.error(`Error clearing tooltip cache: ${error.message}`);
       return null;
     }
   }

--- a/docker.ps1
+++ b/docker.ps1
@@ -18,6 +18,7 @@ function Show-Help {
   shell       - Войти в shell контейнера бота
   mongo-shell - Войти в MongoDB shell (mongosh)
   clear       - Полностью удалить контейнеры, образы и volumes
+  clear-cache - Очистить кеш tooltip_html (loot_tooltip_cache)
   help        - Показать эту справку
 "@
 }
@@ -83,6 +84,15 @@ function Enter-MongoShell {
     docker compose exec mongodb mongosh -u admin -p password --authenticationDatabase admin
 }
 
+
+function Clear-LootTooltipCache {
+    Write-Host "🧹 Очистка кеша tooltip_html (loot_tooltip_cache)..." -ForegroundColor Yellow
+    docker compose exec mongodb mongosh -u admin -p password --authenticationDatabase admin --quiet --eval 'db.getCollection("loot_tooltip_cache").deleteMany({})'
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "✅ Кеш tooltip_html очищен!" -ForegroundColor Green
+    }
+}
+
 function Clear-All {
     Write-Host "⚠️  ВНИМАНИЕ: Эта операция полностью удалит контейнеры, образы и все данные (volumes)!" -ForegroundColor Red
     $confirmation = Read-Host "Вы уверены? Введите 'yes' для подтверждения"
@@ -106,7 +116,7 @@ if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
     exit 1
 }
 
-$validCommands = @("start", "stop", "restart", "logs", "logs-mongo", "build", "status", "shell", "mongo-shell", "clear", "help")
+$validCommands = @("start", "stop", "restart", "logs", "logs-mongo", "build", "status", "shell", "mongo-shell", "clear", "clear-cache", "help")
 if ($Command -notin $validCommands) {
     Write-Host "❌ Неизвестная команда: $Command" -ForegroundColor Red
     Write-Host ""
@@ -132,5 +142,6 @@ switch ($Command) {
     "shell" { Enter-Shell }
     "mongo-shell" { Enter-MongoShell }
     "clear" { Clear-All }
+    "clear-cache" { Clear-LootTooltipCache }
     "help" { Show-Help }
 }

--- a/docker.sh
+++ b/docker.sh
@@ -23,6 +23,7 @@ show_help() {
   shell       - Войти в shell контейнера бота
   mongo-shell - Войти в MongoDB shell (mongosh)
   clear       - Полностью удалить контейнеры, образы и volumes
+  clear-cache - Очистить кеш tooltip_html (loot_tooltip_cache)
   help        - Показать эту справку
 EOF
 }
@@ -80,6 +81,12 @@ enter_mongo_shell() {
     docker compose exec mongodb mongosh -u admin -p password --authenticationDatabase admin
 }
 
+
+clear_loot_tooltip_cache() {
+    echo -e "${YELLOW}🧹 Очистка кеша tooltip_html (loot_tooltip_cache)...${NC}"
+    docker compose exec mongodb mongosh -u admin -p password --authenticationDatabase admin --quiet --eval 'db.getCollection("loot_tooltip_cache").deleteMany({})'
+    echo -e "${GREEN}✅ Кеш tooltip_html очищен!${NC}"
+}
 clear_all() {
     echo -e "${RED}⚠️  ВНИМАНИЕ: Эта операция полностью удалит контейнеры, образы и все данные (volumes)!${NC}"
     read -p "Вы уверены? Введите 'yes' для подтверждения: " confirmation
@@ -140,6 +147,9 @@ case "$1" in
         ;;
     clear)
         clear_all
+        ;;
+    clear-cache)
+        clear_loot_tooltip_cache
         ;;
     help|--help|-h|"")
         show_help

--- a/loot/lootScreenshot.js
+++ b/loot/lootScreenshot.js
@@ -43,7 +43,7 @@ function resolveChromiumExecutablePath() {
 }
 
 async function getTooltipData(page, itemEntry, realmId) {
-  const cached = await db.getLootTooltipCache(itemEntry, realmId);
+  const cached = await db.getLootTooltipCache(itemEntry);
   if (cached?.tooltip_html) {
     return { tooltipHtml: cached.tooltip_html, styles: null };
   }
@@ -68,7 +68,7 @@ async function getTooltipData(page, itemEntry, realmId) {
         (el) => el.outerHTML,
       );
 
-      await db.saveLootTooltipCache(itemEntry, realmId, tooltipHtml);
+      await db.saveLootTooltipCache(itemEntry, tooltipHtml);
 
       return { tooltipHtml, styles };
     } catch (error) {
@@ -321,7 +321,19 @@ async function createLootScreenshotBufferInternal(lootItems, realmId) {
   }
 }
 
+
+async function clearLootTooltipCache() {
+  cachedStyles = null;
+
+  try {
+    await db.clearLootTooltipCache();
+  } catch (error) {
+    logger.error(`Failed to clear loot tooltip cache: ${error.message}`);
+  }
+}
+
 module.exports = {
   createLootScreenshotBuffer,
+  clearLootTooltipCache,
   closeLootScreenshotBrowser: closeBrowser,
 };


### PR DESCRIPTION
### Motivation
- Reduce redundant tooltip cache entries by keying cache per `item_entry` only and provide a programmatic way to clear the tooltip cache from both code and Docker helper scripts. 
- Allow operators to clear only the `loot_tooltip_cache` without destroying volumes or containers via convenient shell/PowerShell commands.

### Description
- Updated the `LootTooltipCache` schema to remove `realm_id` and make the unique index `{ item_entry: 1 }` so the cache is keyed by item only (`db/models/LootTooltipCache.model.js`).
- Refactored repository and service APIs to item-only semantics and added `clearTooltipCache()` on the repository and `clearTooltipCache()` on the service, and exported a bound `clearLootTooltipCache` from the database module (`db/repositories/LootTooltipCacheRepository.js`, `db/services/LootTooltipCacheService.js`, `db/database.js`).
- Added a `clearLootTooltipCache()` helper to `loot/lootScreenshot.js` that clears in-memory `cachedStyles` and invokes the DB clear method and exported it from the module.
- Added `clear-cache` commands to `docker.sh` and `docker.ps1` with new handlers (`clear_loot_tooltip_cache` / `Clear-LootTooltipCache`) that run `mongosh` inside the `mongodb` container to execute `db.getCollection("loot_tooltip_cache").deleteMany({})` without removing volumes.

### Testing
- Ran `node --check` syntax checks for the modified JS files (`db/models/LootTooltipCache.model.js`, `db/repositories/LootTooltipCacheRepository.js`, `db/services/LootTooltipCacheService.js`, `db/database.js`, and `loot/lootScreenshot.js`) and they passed. 
- Validated the shell script with `bash -n docker.sh` and it returned no syntax errors. 
- Attempted to validate `docker.ps1` with PowerShell parser, but `pwsh` is not available in this environment so the PowerShell parse check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cc170a8c4832d86bdecdd904f9725)